### PR TITLE
Add GPT-5.5 Azure OpenAI deployment config

### DIFF
--- a/cc/dev/eastus2/national/openai/terragrunt.hcl
+++ b/cc/dev/eastus2/national/openai/terragrunt.hcl
@@ -20,6 +20,19 @@ inputs = {
   sku_name = "S0"
 
   cognitive_deployments = {
+    "gpt-5.5" = {
+      name = "gpt-5.5"
+      model = {
+        format  = "OpenAI"
+        name    = "gpt-5.5"
+        version = "2026-04-24"
+      }
+      scale = {
+        type     = "GlobalStandard"
+        capacity = 400
+      }
+      rai_policy_name = local.rai_policy_name
+    },
     "text-embedding-3-small" = {
       name = "text-embedding-3-small"
       model = {

--- a/workshop/dev/eastus2/workshop/openai/terragrunt.hcl
+++ b/workshop/dev/eastus2/workshop/openai/terragrunt.hcl
@@ -20,19 +20,6 @@ inputs = {
   sku_name = "S0"
 
   cognitive_deployments = {
-    "gpt-55" = {
-      name = "gpt-5.5"
-      model = {
-        format  = "OpenAI"
-        name    = "gpt-5.5"
-        version = "2026-04-24"
-      }
-      scale = {
-        type     = "GlobalStandard"
-        capacity = 500
-      }
-      rai_policy_name = local.rai_policy_name
-    },
     #"gpt-5" = {
     #  name = "gpt-5"
     #  model = {

--- a/workshop/dev/eastus2/workshop/openai/terragrunt.hcl
+++ b/workshop/dev/eastus2/workshop/openai/terragrunt.hcl
@@ -20,6 +20,19 @@ inputs = {
   sku_name = "S0"
 
   cognitive_deployments = {
+    "gpt-55" = {
+      name = "gpt-5.5"
+      model = {
+        format  = "OpenAI"
+        name    = "gpt-5.5"
+        version = "2026-04-24"
+      }
+      scale = {
+        type     = "GlobalStandard"
+        capacity = 500
+      }
+      rai_policy_name = local.rai_policy_name
+    },
     #"gpt-5" = {
     #  name = "gpt-5"
     #  model = {


### PR DESCRIPTION
## Summary
- add Azure OpenAI deployment config for `gpt-5.5` in `cc/dev/eastus2/national/openai/terragrunt.hcl`
- use model version `2026-04-24`
- keep the existing `GlobalStandard` deployment pattern and RAI policy wiring

## Validation
- model availability reference:
  - https://learn.microsoft.com/zh-tw/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure?tabs=americas%2Caz-global-standard%2Cglobal-standard&pivots=azure-openai#gpt-55
- workshop divergence is intentional for now:
  - this PR only updates the national stack
  - workshop remains unchanged to avoid adding more GlobalStandard quota pressure until workshop demand is confirmed
- RAI policy note:
  - this keeps the same `high-severity-filter-202504` / `Asynchronous_filter` configuration already used by the GPT-5.4 family in the same stack

## Quota / rollout note
- I do not have access to the target Azure subscription quota dashboard or `az cognitiveservices usage list` output from this environment
- please verify eastus2 GlobalStandard headroom before apply
- if quota is not yet available, we should either lower capacity or defer deployment until quota is increased

## Testing
- not run (terraform/terragrunt config change only)
