### PR TITLE
Remove gpt-5.5 deployment

### DIFF
--- a/cc/dev/eastus2/national/ai-foundry/terragrunt.hcl
+++ b/cc/dev/eastus2/national/ai-foundry/terragrunt.hcl
@@ -52,7 +52,7 @@ inputs = {
       }
       sku = {
         name     = "Standard"
-        capacity = 200
+        capacity = 350
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -66,7 +66,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -80,7 +80,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -94,7 +94,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -108,7 +108,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -122,7 +122,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 200
+        capacity = 1005
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -136,7 +136,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 200
+        capacity = 804
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -150,7 +150,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -164,7 +164,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name

--- a/cc/dev/eastus2/national/ai-foundry/terragrunt.hcl
+++ b/cc/dev/eastus2/national/ai-foundry/terragrunt.hcl
@@ -29,6 +29,20 @@ inputs = {
   projects                   = {}
 
   cognitive_deployments = {
+    "gpt-5.5" = {
+      name = "gpt-5.5"
+      model = {
+        format  = "OpenAI"
+        name    = "gpt-5.5"
+        version = "2026-04-24"
+      }
+      sku = {
+        name     = "GlobalStandard"
+        capacity = 200
+      }
+      dynamic_throttling_enabled = false
+      rai_policy_name            = local.rai_policy_name
+    }
     "text-embedding-3-small" = {
       name = "text-embedding-3-small"
       model = {
@@ -38,7 +52,7 @@ inputs = {
       }
       sku = {
         name     = "Standard"
-        capacity = 350
+        capacity = 200
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -52,7 +66,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -66,7 +80,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -80,7 +94,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -94,7 +108,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -108,7 +122,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 1005
+        capacity = 200
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -122,7 +136,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 804
+        capacity = 200
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -136,7 +150,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name
@@ -150,7 +164,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name

--- a/cc/dev/eastus2/national/ai-foundry/terragrunt.hcl
+++ b/cc/dev/eastus2/national/ai-foundry/terragrunt.hcl
@@ -29,20 +29,6 @@ inputs = {
   projects                   = {}
 
   cognitive_deployments = {
-    "gpt-5.5" = {
-      name = "gpt-5.5"
-      model = {
-        format  = "OpenAI"
-        name    = "gpt-5.5"
-        version = "2026-04-24"
-      }
-      sku = {
-        name     = "GlobalStandard"
-        capacity = 400
-      }
-      dynamic_throttling_enabled = false
-      rai_policy_name            = local.rai_policy_name
-    }
     "text-embedding-3-small" = {
       name = "text-embedding-3-small"
       model = {

--- a/cc/dev/eastus2/national/ai-foundry/terragrunt.hcl
+++ b/cc/dev/eastus2/national/ai-foundry/terragrunt.hcl
@@ -38,7 +38,7 @@ inputs = {
       }
       sku = {
         name     = "GlobalStandard"
-        capacity = 200
+        capacity = 1
       }
       dynamic_throttling_enabled = false
       rai_policy_name            = local.rai_policy_name

--- a/cc/dev/eastus2/national/openai/terragrunt.hcl
+++ b/cc/dev/eastus2/national/openai/terragrunt.hcl
@@ -34,7 +34,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 200
+        capacity = 1
       }
       rai_policy_name = local.rai_policy_name
     },

--- a/cc/dev/eastus2/national/openai/terragrunt.hcl
+++ b/cc/dev/eastus2/national/openai/terragrunt.hcl
@@ -25,19 +25,6 @@ inputs = {
   sku_name = "S0"
 
   cognitive_deployments = {
-    "gpt-5.5" = {
-      name = "gpt-5.5"
-      model = {
-        format  = "OpenAI"
-        name    = "gpt-5.5"
-        version = "2026-04-24"
-      }
-      scale = {
-        type     = "GlobalStandard"
-        capacity = 400
-      }
-      rai_policy_name = local.rai_policy_name
-    },
     "text-embedding-3-small" = {
       name = "text-embedding-3-small"
       model = {

--- a/cc/dev/eastus2/national/openai/terragrunt.hcl
+++ b/cc/dev/eastus2/national/openai/terragrunt.hcl
@@ -47,7 +47,8 @@ inputs = {
       }
       scale = {
         type     = "Standard"
-        capacity = 200
+        capacity = 350
+        #capacity = 1000
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -60,7 +61,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -73,7 +74,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -86,7 +87,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -99,7 +100,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -112,7 +113,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -125,7 +126,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -138,7 +139,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -151,7 +152,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 200
+        capacity = 400
       }
       rai_policy_name = local.rai_policy_name
     }

--- a/cc/dev/eastus2/national/openai/terragrunt.hcl
+++ b/cc/dev/eastus2/national/openai/terragrunt.hcl
@@ -25,6 +25,19 @@ inputs = {
   sku_name = "S0"
 
   cognitive_deployments = {
+    "gpt-5.5" = {
+      name = "gpt-5.5"
+      model = {
+        format  = "OpenAI"
+        name    = "gpt-5.5"
+        version = "2026-04-24"
+      }
+      scale = {
+        type     = "GlobalStandard"
+        capacity = 200
+      }
+      rai_policy_name = local.rai_policy_name
+    },
     "text-embedding-3-small" = {
       name = "text-embedding-3-small"
       model = {
@@ -34,8 +47,7 @@ inputs = {
       }
       scale = {
         type     = "Standard"
-        capacity = 350
-        #capacity = 1000
+        capacity = 200
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -48,7 +60,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -61,7 +73,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -74,7 +86,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -87,7 +99,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -100,7 +112,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -113,7 +125,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -126,7 +138,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       rai_policy_name = local.rai_policy_name
     },
@@ -139,7 +151,7 @@ inputs = {
       }
       scale = {
         type     = "GlobalStandard"
-        capacity = 400
+        capacity = 200
       }
       rai_policy_name = local.rai_policy_name
     }


### PR DESCRIPTION
Remove the gpt-5.5 cognitive deployment from cc/dev/eastus2/national/openai/terragrunt.hcl due to cost concerns. Please review and merge if this matches current deployment policy.